### PR TITLE
Measure parallel extraction timings more accurately

### DIFF
--- a/freeze-requirements.txt
+++ b/freeze-requirements.txt
@@ -85,7 +85,7 @@ readability-lxml==0.8.1
 regex==2022.3.2
 requests==2.28.1
 requests-file==1.5.1
-Resiliparse==0.13.5
+Resiliparse==0.13.7
 rich==12.6.0
 rsa==4.7.2
 s3transfer==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ goose3==3.1.12
 trafilatura==1.4.0
 inscriptis==2.3.1
 news-please==1.5.22
-Resiliparse==0.13.5
+Resiliparse==0.13.7
 
 shellingham==1.5.0
 typer==0.4.2


### PR DESCRIPTION
Instead of measuring the total execution time, the parallel benchmarker now measures the individual run times, sums them up and then divides by the number of processes. This is to get a fairer comparison between parallel and sequential run times without adding additional overhead. Now you do not get the actual execution time of the whole framework anymore (which may or may not be useful), but a pretty accurate upper bound for the actual extraction performance on your machine instead.

Items/sec timings on my machine (24 threads, 12 physical cores):

| Library           | Sequential |   MP Pool | Speedup |   Dask Bag | Speedup |
| :---              |       ---: |      ---: |    ---: |       ---: |    ---: |
| boilerpy3         |     60.421 |   852.503 |  14.109 |    893.578 |  14.789 |
| goose3            |      9.547 |   101.012 |  10.581 |    106.293 |  11.134 |
| inscriptis        |     78.656 | 1,109.336 |  14.104 |  1,100.207 |  13.988 |
| news-please       |      5.901 |    73.912 |  12.524 |     72.568 |  12.297 |
| newspaper3k       |     11.011 |   176.869 |  16.063 |    184.811 |  16.785 |
| resiliparse-plain |    752.817 | 7,364.581 |   9.783 | 10,444.290 |  13.874 |
| resiliparse       |    493.440 | 5,021.836 |  10.177 |  6,070.188 |  12.302 |
| trafilatura       |     37.586 |   529.277 |  14.082 |    564.411 |  15.017 |


Most tools show a speedup of around 10-14x, which is to be expected on this CPU. An exception is newspaper3k, which seems to benefit a lot more than others.

The timings are largely independent of the parallelisation backend due to the way they are measured with the exception of Resiliparse, which is significantly faster with Dask now. My guess is that there is some Python latency involved when processes are reused for multiple calls instead of spawning a new process for each one individually. Not reusing processes is a lot less efficient overall, but apparently results in shorter execution times for the individual calls. Again, these are probably effects you see only because Resiliparse's latency is so low that it becomes bottlenecked by the Python runtime itself.